### PR TITLE
Compatible with OpenCV 4

### DIFF
--- a/build/detector/HoughLinespDetector.cpp
+++ b/build/detector/HoughLinespDetector.cpp
@@ -105,8 +105,11 @@ void HoughLinespDetector::DebugView(cv::Mat& image, std::vector<cv::Vec4i>& line
 #ifdef _DEBUG
   static Poco::Int64 interval = 0;
   cv::Mat view;
+  #if (CV_VERSION_MAJOR >= 4)
+  cv::cvtColor(image, view, cv::COLOR_GRAY2BGR);
+  #else
   cv::cvtColor(image, view, CV_GRAY2BGR);
-
+  #endif
   bool flag = false;
   if (linesp.size() > 0) {
     cv::Vec4i pt = linesp.at(0);

--- a/build/normalizer/SizeNormalizer.cpp
+++ b/build/normalizer/SizeNormalizer.cpp
@@ -56,7 +56,11 @@ void SizeNormalizer::Run(ImageHolder::Ptr frame) {
   }
 
   if (gray_) {
+    #if (CV_VERSION_MAJOR >= 4)
+    cv::cvtColor(frame->frame_, frame->frame_, cv::COLOR_RGB2GRAY);
+    #else
     cv::cvtColor(frame->frame_, frame->frame_, CV_RGB2GRAY);
+    #endif
   }
 }
 


### PR DESCRIPTION
Hello,

The OpenCV had released the major version 4.
Some macros in your code had deprecated in opencv 4.
More information see https://www.ybliu.com/2020/05/CVGRAY2BGR%20not%20declared.html

regards.